### PR TITLE
fix: replace deprecated Flask hook

### DIFF
--- a/all_cams.py
+++ b/all_cams.py
@@ -51,7 +51,11 @@ def capture_frames(idx: int) -> None:
                 latest_frames[idx] = frame.copy()
 
 
-@app.before_first_request
+# Flask 3 removed the ``before_first_request`` hook. ``before_request`` runs
+# before *every* request, so we guard initialization with the ``_initialized``
+# flag already present in ``init_cameras``. This keeps the previous behaviour of
+# setting up the camera resources lazily only once.
+@app.before_request
 def setup_cameras() -> None:
     init_cameras()
 


### PR DESCRIPTION
## Summary
- avoid Flask 3 `before_first_request` removal by hooking camera initialization into `before_request`

## Testing
- `python -m py_compile all_cams.py`


------
https://chatgpt.com/codex/tasks/task_e_68a849bcaf908328a61e9a40a53b46b7