### PR TITLE
Add resilient watchdog handling for camera restarts

### DIFF
--- a/new_gui.py
+++ b/new_gui.py
@@ -94,9 +94,15 @@ def watchdog():
         time.sleep(5)
         if time.time() - last_frame_time > 5:
             print("Watchdog: restarting camera transfer")
-            cam.endXfer()
-            cam.beginXfer(callback)
-            last_frame_time = time.time()
+            try:
+                cam.endXfer()
+                cam.beginXfer(callback)
+            except RuntimeError as exc:
+                # Log the failure and pause briefly before retrying so the thread survives
+                print(f"Watchdog: restart failed: {exc}")
+                time.sleep(1)
+            else:
+                last_frame_time = time.time()
 
 
 processor_thread = threading.Thread(target=process_frames, daemon=True)


### PR DESCRIPTION
## Summary
- Handle RuntimeError when restarting camera transfer in `watchdog`
- Log failures and back off briefly to keep the watchdog thread alive

## Testing
- `python -m py_compile new_gui.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a853abfea883288451dccf811ba8f5