### PR TITLE
Ensure camera resources are released on exit

### DIFF
--- a/new_gui.py
+++ b/new_gui.py
@@ -194,6 +194,7 @@ if __name__ == '__main__':
         app.run(host='0.0.0.0', port=5000, threaded=True)
     finally:
         cam.endXfer()
+        cam.close()
         if fcreator is not None:
             fcreator.close()
             FileCreator.create_json(current_file, cam)


### PR DESCRIPTION
## Summary
- Close the camera after ending the transfer in `new_gui` so hardware resources are freed even if startup fails.

## Testing
- `python -m py_compile new_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8541b47308328a8d636b9e3793b47