### PR TITLE
Add serial sender and receiver example

### DIFF
--- a/serial_demo/main.cpp
+++ b/serial_demo/main.cpp
@@ -1,0 +1,55 @@
+#include <chrono>
+#include <cstring>
+#include <fcntl.h>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <termios.h>
+#include <unistd.h>
+
+int main() {
+    const char* port = "/dev/ttyUSB0"; // adjust to your serial port
+    int fd = open(port, O_WRONLY | O_NOCTTY);
+    if (fd < 0) {
+        std::perror("open");
+        return 1;
+    }
+
+    termios tty{};
+    if (tcgetattr(fd, &tty) != 0) {
+        std::perror("tcgetattr");
+        close(fd);
+        return 1;
+    }
+
+    cfsetispeed(&tty, B115200);
+    cfsetospeed(&tty, B115200);
+    tty.c_cflag = (tty.c_cflag & ~CSIZE) | CS8;
+    tty.c_iflag &= ~IGNBRK;
+    tty.c_lflag = 0;
+    tty.c_oflag = 0;
+    tty.c_cc[VMIN]  = 0;
+    tty.c_cc[VTIME] = 5;
+    tty.c_iflag &= ~(IXON | IXOFF | IXANY);
+    tty.c_cflag |= (CLOCAL | CREAD);
+    tty.c_cflag &= ~(PARENB | PARODD);
+    tty.c_cflag &= ~CSTOPB;
+    tty.c_cflag &= ~CRTSCTS;
+
+    if (tcsetattr(fd, TCSANOW, &tty) != 0) {
+        std::perror("tcsetattr");
+        close(fd);
+        return 1;
+    }
+
+    const auto interval = std::chrono::microseconds(100); // 10 kHz
+    int count = 0;
+    while (true) {
+        std::string msg = std::to_string(count++) + "\n";
+        write(fd, msg.c_str(), msg.size());
+        std::this_thread::sleep_for(interval);
+    }
+
+    close(fd);
+    return 0;
+}

--- a/serial_demo/receiver.py
+++ b/serial_demo/receiver.py
@@ -1,0 +1,20 @@
+import serial
+import time
+
+PORT = '/dev/ttyUSB0'  # adjust to your serial port
+BAUD = 115200
+
+with serial.Serial(PORT, BAUD, timeout=1) as ser:
+    last = None
+    while True:
+        line = ser.readline()
+        if not line:
+            continue
+        now = time.time()
+        text = line.decode(errors='ignore').strip()
+        if last is not None:
+            freq = 1.0 / (now - last)
+            print(f"{text} (freq: {freq:.2f} Hz)")
+        else:
+            print(text)
+        last = now


### PR DESCRIPTION
## Summary
- Add `main.cpp` example that writes incrementing numbers to a serial port at ~10 kHz.
- Add Python receiver using `pyserial` to print incoming data and its measured frequency.

## Testing
- `g++ serial_demo/main.cpp -o serial_demo/sender -std=c++17`
- `python3 -m py_compile serial_demo/receiver.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8a1d6d6408328b78af7fe69a8d5b3